### PR TITLE
Added support for row attributes and callable cell attributes.

### DIFF
--- a/src/Examples/test1.php
+++ b/src/Examples/test1.php
@@ -14,6 +14,12 @@ $table = \Jupitern\Table\Table::instance()
 	->attr('class', 'table table-bordered table-striped table-hover')
 	->attr('cellspacing', '0')
 	->attr('width', '100%')
+	->rowAttr('class', function($row) {
+		return $row['age'] > 40 ? 'info' : '';
+	})
+	->rowAttr('data-id', function ($row) {
+		return 'row-' . $row['id'];
+	})
 	->column()
 		->title('Name')
 		->value(function ($row) {
@@ -28,6 +34,12 @@ $table = \Jupitern\Table\Table::instance()
 		->value('age')
 		->css('color', 'red')
 		->css('width', '20%')
+		->attr('data-age', function($row) {
+			return $row['age'];
+		})
+		->css('color', function($row) {
+			return $row['age'] > 40 ? '#00f' : 'inherit';
+		})
 	->add()
 	->column('Phone')
 		->value('phone')

--- a/src/Table/Properties.php
+++ b/src/Table/Properties.php
@@ -19,13 +19,25 @@ class Properties
 		return $this;
 	}
 
-	public function render($template)
+	public function render($template, $context = null)
 	{
 		$output = '';
 		foreach ((array)$this->properties as $prop => $val) {
+			$val = $this->getValue($val, $context);
 			$output .= str_replace(['{prop}', '{val}'], [$prop, $val], $template);
 		}
 		return $output;
+	}
+
+	public function getValue($value, $context)
+	{
+		$val = "";
+		if (is_callable($value)) {
+			$val = $value($context);
+		} else {
+			$val = $value;
+		}
+		return $val;
 	}
 
 }

--- a/src/Table/Table.php
+++ b/src/Table/Table.php
@@ -7,10 +7,11 @@ class Table
 	public $columns;
 	public $hasFilters;
 
-	private $data;
-	private $css;
-	private $attrs;
-	private $tablePlugin;
+	protected $data;
+	protected $css;
+	protected $attrs;
+	protected $rowAttrs;
+	protected $tablePlugin;
 	public $titlesMode = null;
 
 
@@ -18,6 +19,7 @@ class Table
 	{
 		$this->css = new Properties();
 		$this->attrs = new Properties();
+		$this->rowAttrs = new Properties();
 		$this->hasFilters = false;
 	}
 
@@ -85,6 +87,31 @@ class Table
 	}
 
 	/**
+	 * add html table row attribute
+	 *
+	 * @param $attr
+	 * @param $value
+	 * @return $this
+	 */
+	public function rowAttr($attr, $value)
+	{
+		$this->rowAttrs->add($attr, $value);
+		return $this;
+	}
+
+	/**
+	 * add html table row attributes
+	 *
+	 * @param $attrs
+	 * @return $this
+	 */
+	public function rowAttrs($attrs)
+	{
+		$this->rowAttrs->addAll($attrs);
+		return $this;
+	}
+
+	/**
 	 * add html table style
 	 *
 	 * @param $attr
@@ -131,14 +158,17 @@ class Table
 			$theadFilters .= $column->renderFilter();
 		}
 
+		$rowTemplate = "<tr {attrs}>{cells}</tr>\n";
+
 		$tbody = '';
 		if (count($this->data)) {
 			foreach ($this->data as $row) {
-				$tbody .= '<tr>';
+				$cells = '';
 				foreach ((array)$this->columns as $column) {
-					$tbody .= $column->renderBody($row);
+					$cells .= $column->renderBody($row);
 				}
-				$tbody .= '</tr>';
+				$rowAttrs = $this->rowAttrs->render("{prop}='{val}' ", $row);
+				$tbody .= str_replace(['{attrs}','{cells}'], [$rowAttrs, $cells], $rowTemplate);
 			}
 		}
 
@@ -153,7 +183,7 @@ class Table
 			],
 			$html
 		);
-		
+
 		if (!$returnOutput) echo $output;
 		return $output;
 	}

--- a/src/Table/TableColumn.php
+++ b/src/Table/TableColumn.php
@@ -118,7 +118,7 @@ Class TableColumn
 		if ($this->title === false) {
 			return "";
 		}
-		
+
 		if (empty($this->title) && !is_callable($this->value)) {
 			if ($this->tableInstance->titlesMode == 'underscore') $this->title = $this->underscoreToTitle($this->value);
 			elseif ($this->tableInstance->titlesMode == 'camelcase') $this->title = $this->camelToTitle($this->value);
@@ -166,8 +166,8 @@ Class TableColumn
 	public function renderBody( &$row )
 	{
 		$template = '<td {attrs} style="{css}">{val}</td>';
-		$attrs = $this->attrs['body']->render('{prop}="{val}" ');
-		$css = $this->css['body']->render('{prop}:{val}; ');
+		$attrs = $this->attrs['body']->render('{prop}="{val}" ', $row);
+		$css = $this->css['body']->render('{prop}:{val}; ', $row);
 
 		$val = "";
 		if (is_callable($this->value)) {


### PR DESCRIPTION
Hi there, thanks for this library! 🙌 

I've been using it for a while in a project I'm working on and have found it really useful, but came up with a requirement to customise the generated `<tr>` elements (e.g. adding `data-` and `class` attributes).

First I tried creating a new class to extend it, but had problems due to the variables being declared private; so I forked it instead - you can see the changes here.

I updated test1.php example with some use cases - setting the 'class' and adding a data-id attribute based on row properties.

The way I achieved this - updating Properties class to support callables - also means that the attr() and css() calls for cells can also have values returned from callables.

Please feel free to merge if you find it useful!